### PR TITLE
[PaddlePaddle Hackathon]77 为哈密顿量矩阵实现指定量子比特数

### DIFF
--- a/paddle_quantum/circuit.py
+++ b/paddle_quantum/circuit.py
@@ -59,7 +59,7 @@ class UAnsatz:
                         paddle.to_tensor(np.array([math.pi / 4])), paddle.to_tensor(np.array([-math.pi / 4]))]
         # Record history of adding gates to the circuit
         self.__history = []
-       
+
     def __add__(self, cir):
         r"""重载加法 ‘+’ 运算符，用于拼接两个维度相同的电路
 

--- a/paddle_quantum/circuit.py
+++ b/paddle_quantum/circuit.py
@@ -59,6 +59,15 @@ class UAnsatz:
                         paddle.to_tensor(np.array([math.pi / 4])), paddle.to_tensor(np.array([-math.pi / 4]))]
         # Record history of adding gates to the circuit
         self.__history = []
+        
+    def expand(self,new_n):
+        """
+        为原来的量子电路进行比特数扩展
+
+        Args：
+            new_n(int):扩展后的量子比特数
+        """
+        self.n = new_n
 
     def __add__(self, cir):
         r"""重载加法 ‘+’ 运算符，用于拼接两个维度相同的电路

--- a/paddle_quantum/circuit.py
+++ b/paddle_quantum/circuit.py
@@ -59,16 +59,7 @@ class UAnsatz:
                         paddle.to_tensor(np.array([math.pi / 4])), paddle.to_tensor(np.array([-math.pi / 4]))]
         # Record history of adding gates to the circuit
         self.__history = []
-        
-    def expand(self,new_n):
-        """
-        为原来的量子电路进行比特数扩展
-
-        Args：
-            new_n(int):扩展后的量子比特数
-        """
-        self.n = new_n
-
+       
     def __add__(self, cir):
         r"""重载加法 ‘+’ 运算符，用于拼接两个维度相同的电路
 

--- a/paddle_quantum/utils.py
+++ b/paddle_quantum/utils.py
@@ -914,14 +914,14 @@ class Hamiltonian:
             pass
         return self.coefficients, self.__pauli_words
 
-    def construct_h_matrix(self):
+    def construct_h_matrix(self，n_qubit):
         r"""构建 Hamiltonian 在 Z 基底下的矩阵。
 
         Returns:
             np.ndarray: Z 基底下的哈密顿量矩阵形式
         """
         coefs, pauli_words, sites = self.decompose_with_sites()
-        n_qubit = 1
+        assert n_qubit>=self.num_qubit,"输入的量子数不小于哈密顿量表达式中所对应的量子比特数"
         for site in sites:
             if type(site[0]) is int:
                 n_qubit = max(n_qubit, max(site) + 1)


### PR DESCRIPTION
Task: https://github.com/PaddlePaddle/Quantum/issues/13

使得 Hamiltonian.construct_h_matrix() 方法支持传入参数 n_qubit 来指定生成矩阵对应的量子比特数（该参数应该不小于哈密顿量表达式中所对应的量子比特数）。